### PR TITLE
Make commands optional

### DIFF
--- a/src/core_plugins/kibana/public/home/components/tutorial/instruction.js
+++ b/src/core_plugins/kibana/public/home/components/tutorial/instruction.js
@@ -19,16 +19,13 @@ export function Instruction({ commands, paramValues, textPost, textPre }) {
     post = <Content className="kuiVerticalRhythm" text={textPost}/>;
   }
 
-  const aceOptions = {
-    fontSize: '14px',
-    maxLines: commands.length
-  };
-
-  return (
-    <div className="instruction">
-
-      {pre}
-
+  let commandsMarkup;
+  if (commands) {
+    const aceOptions = {
+      fontSize: '14px',
+      maxLines: commands.length
+    };
+    commandsMarkup = (
       <div className="kuiVerticalRhythm">
         <KuiCodeEditor
           mode="sh"
@@ -39,7 +36,14 @@ export function Instruction({ commands, paramValues, textPost, textPre }) {
           isReadOnly
         />
       </div>
+    );
+  }
 
+  return (
+    <div className="instruction">
+
+      {pre}
+      {commandsMarkup}
       {post}
 
     </div>
@@ -47,7 +51,6 @@ export function Instruction({ commands, paramValues, textPost, textPre }) {
 }
 
 Instruction.propTypes = {
-  commands: PropTypes.array.isRequired,
   paramValues: PropTypes.object.isRequired,
   textPost: PropTypes.string,
   textPre: PropTypes.string,

--- a/src/core_plugins/kibana/public/home/components/tutorial/instruction.js
+++ b/src/core_plugins/kibana/public/home/components/tutorial/instruction.js
@@ -51,6 +51,7 @@ export function Instruction({ commands, paramValues, textPost, textPre }) {
 }
 
 Instruction.propTypes = {
+  commands: PropTypes.array,
   paramValues: PropTypes.object.isRequired,
   textPost: PropTypes.string,
   textPre: PropTypes.string,


### PR DESCRIPTION
In certain cases it is necessary to not have any commands present for an instruction. For example, it might be desirable to provide the instruction as text with a link to a third-party web site containing authoritative instructions.

This PR allows for such use cases by making `commands` optional.