### PR TITLE
Add cloud version of the apache_logs tutorial

### DIFF
--- a/src/core_plugins/kibana/common/tutorials/filebeat_onprem_cloud_instructions.js
+++ b/src/core_plugins/kibana/common/tutorials/filebeat_onprem_cloud_instructions.js
@@ -1,0 +1,71 @@
+export const FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS = {
+  TRYCLOUD_OPTION1: {
+    title: 'Option 1: Try module in Elastic Cloud',
+    textPre: 'Go to [Elastic Cloud](https://cloud.elastic.co/). Register if you ' +
+             'don\'t have an account.\n' +
+             ' * Select **Create Cluster**, leave size slider at 4 GB RAM, and click **Create**\n' +
+             ' * Wait for the cluster plan to complete.\n' +
+             ' * Go to the new Cloud Kibana instance and follow the Kibana Home instructions.'
+
+  },
+  TRYCLOUD_OPTION2: {
+    title: 'Option 2: Local Kibana connected to a Cloud instance',
+    textPre: 'If you are running this Kibana instance against a hosted Elasticsearch instance,' +
+             ' proceed with manual setup.\n' +
+             ' * In **Overview >> Endpoints** note **Elasticsearch** as `<es_url>`'
+  },
+  CONFIG: {
+    OSX: {
+      title: 'Edit the configuration',
+      textPre: 'Modify `filebeat.yml` to set the connection information:',
+      commands: [
+        'setup.kibana:',
+        '  host: "<<kibana-host>>:5601"',
+        'output.elasticsearch:',
+        '  hosts: ["<es_url>:9200"]',
+        '  username: "elastic"',
+        '  password: "<password>"'
+      ],
+      textPost: 'Where `<password>` is the password of the `elastic` user.'
+    },
+    DEB: {
+      title: 'Edit the configuration',
+      textPre: 'Modify `/etc/filebeat/filebeat.yml` to set the connection information:',
+      commands: [
+        'setup.kibana:',
+        '  host: "<<kibana-host>>:5601"',
+        'output.elasticsearch:',
+        '  hosts: ["<es_url>:9200"]',
+        '  username: "elastic"',
+        '  password: "<password>"'
+      ],
+      textPost: 'Where `<password>` is the password of the `elastic` user.'
+    },
+    RPM: {
+      title: 'Edit the configuration',
+      textPre: 'Modify `/etc/filebeat/filebeat.yml` to set the connection information:',
+      commands: [
+        'setup.kibana:',
+        '  host: "<<kibana-host>>:5601"',
+        'output.elasticsearch:',
+        '  hosts: ["<es_url>:9200"]',
+        '  username: "elastic"',
+        '  password: "<password>"'
+      ],
+      textPost: 'Where `<password>` is the password of the `elastic` user.'
+    },
+    WINDOWS: {
+      title: 'Edit the configuration',
+      textPre: 'Modify `C:\\Program Files\\Filebeat\\filebeat.yml` to set the connection information:',
+      commands: [
+        'setup.kibana:',
+        '  host: "<<kibana-host>>:5601"',
+        'output.elasticsearch:',
+        '  hosts: ["<es_url>:9200"]',
+        '  username: "elastic"',
+        '  password: "<password>"'
+      ],
+      textPost: 'Where `<password>` is the password of the `elastic` user.'
+    }
+  }
+};

--- a/src/core_plugins/kibana/server/tutorials/apache_logs/on_prem_elastic_cloud.js
+++ b/src/core_plugins/kibana/server/tutorials/apache_logs/on_prem_elastic_cloud.js
@@ -1,4 +1,7 @@
 import { INSTRUCTION_VARIANT } from '../../../common/tutorials/instruction_variant';
+import { FILEBEAT_INSTRUCTIONS } from '../../../common/tutorials/filebeat_instructions';
+import { FILEBEAT_CLOUD_INSTRUCTIONS } from '../../../common/tutorials/filebeat_cloud_instructions';
+import { FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS } from '../../../common/tutorials/filebeat_onprem_cloud_instructions';
 
 export const ON_PREM_ELASTIC_CLOUD_INSTRUCTIONS = {
   instructionSets: [
@@ -8,9 +11,71 @@ export const ON_PREM_ELASTIC_CLOUD_INSTRUCTIONS = {
         {
           id: INSTRUCTION_VARIANT.OSX,
           instructions: [
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION1,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION2,
+            FILEBEAT_CLOUD_INSTRUCTIONS.INSTALL.OSX,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.CONFIG.OSX,
             {
-              title: 'onPremElasticCloud instructions - TBD',
-            }
+              title: 'Enable and configure the apache2 module',
+              textPre: 'From the installation directory, run:',
+              commands: [
+                './filebeat modules enable apache2',
+              ],
+              textPost: 'Modify the settings in the `modules.d/apache2.yml` file.'
+            },
+            FILEBEAT_INSTRUCTIONS.START.OSX
+          ]
+        },
+        {
+          id: INSTRUCTION_VARIANT.DEB,
+          instructions: [
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION1,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION2,
+            FILEBEAT_CLOUD_INSTRUCTIONS.INSTALL.DEB,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.CONFIG.DEB,
+            {
+              title: 'Enable and configure the apache2 module',
+              commands: [
+                'sudo filebeat modules enable apache2',
+              ],
+              textPost: 'Modify the settings in the `/etc/filebeat/modules.d/apache2.yml` file.'
+            },
+            FILEBEAT_INSTRUCTIONS.START.DEB
+          ]
+        },
+        {
+          id: INSTRUCTION_VARIANT.RPM,
+          instructions: [
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION1,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION2,
+            FILEBEAT_CLOUD_INSTRUCTIONS.INSTALL.RPM,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.CONFIG.RPM,
+            {
+              title: 'Enable and configure the apache2 module',
+              commands: [
+                'sudo filebeat modules enable apache2',
+              ],
+              textPost: 'Modify the settings in the `/etc/filebeat/modules.d/apache2.yml` file.'
+            },
+            FILEBEAT_INSTRUCTIONS.START.RPM
+          ]
+        },
+        {
+          id: INSTRUCTION_VARIANT.WINDOWS,
+          instructions: [
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION1,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.TRYCLOUD_OPTION2,
+            FILEBEAT_CLOUD_INSTRUCTIONS.INSTALL.WINDOWS,
+            FILEBEAT_ONPREM_CLOUD_INSTRUCTIONS.CONFIG.WINDOWS,
+            {
+              title: 'Enable and configure the apache2 module',
+              textPre: 'From the `C:\\Program Files\\Filebeat` folder, run:',
+              commands: [
+                'PS C:\\Program Files\\Filebeat> filebeat.exe modules enable apache2',
+              ],
+              textPost: 'Modify the settings in the `modules.d/apache2.yml` file.'
+            },
+            FILEBEAT_INSTRUCTIONS.START.WINDOWS
           ]
         }
       ]


### PR DESCRIPTION
Adds the cloud version of the tutorial for apache_logs. Also adds the dashboard ID for the apache logs module, but that is currently rejected by Kibana, so I commented it out.