### PR TITLE
[Netflow tutorial] Windows instructions

### DIFF
--- a/src/core_plugins/kibana/common/tutorials/logstash_instructions.js
+++ b/src/core_plugins/kibana/common/tutorials/logstash_instructions.js
@@ -12,6 +12,18 @@ export const LOGSTASH_INSTRUCTIONS = {
           'tar xzvf logstash-{config.kibana.version}.tar.gz'
         ]
       }
-    ]
+    ],
+    WINDOWS: [
+      {
+        title: 'Download and install the Java runtime environment',
+        textPre: `Follow the installation instructions [here](https://docs.oracle.com/javase/8/docs/technotes/guides/install/windows_jre_install.html). ` +
+          `${SKIP_INSTALL_SENTENCE} ${FIRST_TIME_SENTENCE}`
+      },
+      {
+        title: 'Download and install Logstash',
+        textPre: `Download Logstash from [here](https://artifacts.elastic.co/downloads/logstash/logstash-{config.kibana.version}.zip) and unzip it. ` +
+          SKIP_INSTALL_SENTENCE
+      }
+    ],
   }
 };

--- a/src/core_plugins/kibana/common/tutorials/logstash_instructions.js
+++ b/src/core_plugins/kibana/common/tutorials/logstash_instructions.js
@@ -16,13 +16,11 @@ export const LOGSTASH_INSTRUCTIONS = {
     WINDOWS: [
       {
         title: 'Download and install the Java runtime environment',
-        textPre: `Follow the installation instructions [here](https://docs.oracle.com/javase/8/docs/technotes/guides/install/windows_jre_install.html). ` +
-          `${SKIP_INSTALL_SENTENCE} ${FIRST_TIME_SENTENCE}`
+        textPre: 'Follow the installation instructions [here](https://docs.oracle.com/javase/8/docs/technotes/guides/install/windows_jre_install.html).'
       },
       {
         title: 'Download and install Logstash',
-        textPre: `Download Logstash from [here](https://artifacts.elastic.co/downloads/logstash/logstash-{config.kibana.version}.zip) and unzip it. ` +
-          SKIP_INSTALL_SENTENCE
+        textPre: 'Download Logstash from [here](https://artifacts.elastic.co/downloads/logstash/logstash-{config.kibana.version}.zip) and unzip it.'
       }
     ],
   }

--- a/src/core_plugins/kibana/server/tutorials/netflow/common_instructions.js
+++ b/src/core_plugins/kibana/server/tutorials/netflow/common_instructions.js
@@ -14,6 +14,20 @@ export const COMMON_NETFLOW_INSTRUCTIONS = {
             '    var.kibana.host: "<kibana_hostname>:<kibana_port>"'
           ]
         }
+      ],
+      WINDOWS: [
+        {
+          title: 'Edit the configuration',
+          textPre: 'While in the Logstash install directory, modify `config\\logstash.yml` to set the'
+            + ' configuration parameters for the Netflow module:',
+          commands: [
+            'modules:',
+            '  - name: netflow',
+            '    var.input.udp.port: <udp_port_for_receving_netflow_data>',
+            '    var.elasticsearch.hosts: [ "<es_url>" ]',
+            '    var.kibana.host: "<kibana_hostname>:<kibana_port>"'
+          ]
+        }
       ]
     },
     ELASTIC_CLOUD: {
@@ -41,6 +55,18 @@ export const COMMON_NETFLOW_INSTRUCTIONS = {
         textPre: 'In the Logstash installation directory, run the following command to set up the Netflow module.',
         commands: [
           './bin/logstash --modules netflow --setup',
+        ],
+        textPost: 'The `--setup` option creates a `netflow-*` index pattern in Elasticsearch and imports' +
+          ' Kibana dashboards and visualizations. Omit this option for subsequent runs of the module to avoid' +
+          '  overwriting existing Kibana dashboards.'
+      }
+    ],
+    WINDOWS: [
+      {
+        title: 'Set up and run the Netflow module',
+        textPre: 'In the Logstash install directory, run the following command to set up the Netflow module.',
+        commands: [
+          'bin\\logstash --modules netflow --setup',
         ],
         textPost: 'The `--setup` option creates a `netflow-*` index pattern in Elasticsearch and imports' +
           ' Kibana dashboards and visualizations. Omit this option for subsequent runs of the module to avoid' +

--- a/src/core_plugins/kibana/server/tutorials/netflow/common_instructions.js
+++ b/src/core_plugins/kibana/server/tutorials/netflow/common_instructions.js
@@ -45,6 +45,20 @@ export const COMMON_NETFLOW_INSTRUCTIONS = {
           ],
           textPost: 'Where `<password>` is the password of the `elastic` user.'
         }
+      ],
+      WINDOWS: [
+        {
+          title: 'Edit the configuration',
+          textPre: 'While in the Logstash install directory, modify `config\\logstash.yml` to set the'
+            + ' configuration parameters for the Netflow module:',
+          commands: [
+            'modules:',
+            '  - name: netflow',
+            '    var.input.udp.port: <udp_port_for_receving_netflow_data>',
+            '    cloud.id: "{config.cloud.id}"',
+            '    cloud.auth: "elastic:<password>"'
+          ]
+        }
       ]
     }
   },

--- a/src/core_plugins/kibana/server/tutorials/netflow/elastic_cloud.js
+++ b/src/core_plugins/kibana/server/tutorials/netflow/elastic_cloud.js
@@ -15,6 +15,14 @@ export const ELASTIC_CLOUD_INSTRUCTIONS = {
             ...COMMON_NETFLOW_INSTRUCTIONS.CONFIG.ELASTIC_CLOUD.OSX,
             ...COMMON_NETFLOW_INSTRUCTIONS.SETUP.OSX
           ]
+        },
+        {
+          id: INSTRUCTION_VARIANT.WINDOWS,
+          instructions: [
+            ...LOGSTASH_INSTRUCTIONS.INSTALL.WINDOWS,
+            ...COMMON_NETFLOW_INSTRUCTIONS.CONFIG.ELASTIC_CLOUD.WINDOWS,
+            ...COMMON_NETFLOW_INSTRUCTIONS.SETUP.WINDOWS
+          ]
         }
       ]
     }

--- a/src/core_plugins/kibana/server/tutorials/netflow/on_prem.js
+++ b/src/core_plugins/kibana/server/tutorials/netflow/on_prem.js
@@ -15,6 +15,14 @@ export const ON_PREM_INSTRUCTIONS = {
             ...COMMON_NETFLOW_INSTRUCTIONS.CONFIG.ON_PREM.OSX,
             ...COMMON_NETFLOW_INSTRUCTIONS.SETUP.OSX
           ]
+        },
+        {
+          id: INSTRUCTION_VARIANT.WINDOWS,
+          instructions: [
+            ...LOGSTASH_INSTRUCTIONS.INSTALL.WINDOWS,
+            ...COMMON_NETFLOW_INSTRUCTIONS.CONFIG.ON_PREM.WINDOWS,
+            ...COMMON_NETFLOW_INSTRUCTIONS.SETUP.WINDOWS
+          ]
         }
       ]
     }

--- a/src/core_plugins/kibana/server/tutorials/netflow/on_prem_elastic_cloud.js
+++ b/src/core_plugins/kibana/server/tutorials/netflow/on_prem_elastic_cloud.js
@@ -21,6 +21,16 @@ export const ON_PREM_ELASTIC_CLOUD_INSTRUCTIONS = {
             ...COMMON_NETFLOW_INSTRUCTIONS.CONFIG.ON_PREM.OSX,
             ...COMMON_NETFLOW_INSTRUCTIONS.SETUP.OSX
           ]
+        },
+        {
+          id: INSTRUCTION_VARIANT.WINDOWS,
+          instructions: [
+            TRYCLOUD_OPTION1,
+            TRYCLOUD_OPTION2,
+            ...LOGSTASH_INSTRUCTIONS.INSTALL.WINDOWS,
+            ...COMMON_NETFLOW_INSTRUCTIONS.CONFIG.ON_PREM.WINDOWS,
+            ...COMMON_NETFLOW_INSTRUCTIONS.SETUP.WINDOWS
+          ]
         }
       ]
     }


### PR DESCRIPTION
This PR adds Windows instructions for the Logstash Netflow module tutorial for all three scenarios — on-prem, on-prem w/ Elastic Cloud, and Elastic Cloud.

Thanks to @danhermann for testing out the instructions on a Windows machine!