### PR TITLE
Cleanup tag usage

### DIFF
--- a/src/core_plugins/kibana/public/management/sections/tags/components/tag_form.js
+++ b/src/core_plugins/kibana/public/management/sections/tags/components/tag_form.js
@@ -8,6 +8,7 @@ import {
   EuiFormRow,
   EuiFieldText,
   EuiButton,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
 
@@ -121,19 +122,21 @@ export class TagForm extends React.Component {
           />
         </EuiFormRow>
 
-        <EuiFlexGroup gutterSize="s" alignItems="center">
+        <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiButtonEmpty
+              size="s"
               onClick={this.props.onCancel}
             >
               Cancel
-            </EuiButton>
+            </EuiButtonEmpty>
           </EuiFlexItem>
 
           <EuiFlexItem grow={false}>
             <EuiButton
               fill
               onClick={this.handleSaveClick}
+              size="s"
             >
               Save
             </EuiButton>
@@ -160,4 +163,3 @@ TagForm.defaultProps = {
     }
   }
 };
-

--- a/src/core_plugins/kibana/public/management/sections/tags/components/tag_form_popover.js
+++ b/src/core_plugins/kibana/public/management/sections/tags/components/tag_form_popover.js
@@ -1,4 +1,7 @@
-import React from 'react';
+import React, {
+  cloneElement,
+} from 'react';
+
 import PropTypes from 'prop-types';
 import { TagForm } from './tag_form';
 
@@ -39,11 +42,7 @@ export class TagFormPopover extends React.Component {
       <EuiPopover
         id="tagFormPopover"
         ownFocus
-        button={(
-          <div onClick={this.onBtnClick}>
-            {this.props.button}
-          </div>
-        )}
+        button={cloneElement(this.props.button, { onClick: this.onBtnClick })}
         isOpen={this.state.show}
         closePopover={this.close}
         anchorPosition={this.props.anchorPosition}
@@ -70,5 +69,3 @@ TagFormPopover.propTypes = {
   onSuccessfulSave: PropTypes.func.isRequired,
   anchorPosition: PropTypes.string,
 };
-
-

--- a/src/core_plugins/kibana/public/management/sections/tags/components/tag_listing.js
+++ b/src/core_plugins/kibana/public/management/sections/tags/components/tag_listing.js
@@ -196,7 +196,7 @@ export class TagListing extends React.Component {
           <EuiFlexItem grow={false}>
             <TagFormPopover
               button={(
-                <EuiButton>
+                <EuiButton fill>
                   Create tag
                 </EuiButton>
               )}
@@ -222,5 +222,3 @@ TagListing.propTypes = {
   delete: PropTypes.func.isRequired,
   find: PropTypes.func.isRequired,
 };
-
-

--- a/src/ui/public/tags/components/tags_input.js
+++ b/src/ui/public/tags/components/tags_input.js
@@ -3,9 +3,9 @@ import React, { Component } from 'react';
 import { TagsSelect } from './tags_select';
 
 import {
-  EuiFilterGroup,
   EuiBadge,
-  EuiFilterButton,
+  EuiFlexItem,
+  EuiFlexGroup,
 } from '@elastic/eui';
 
 export class TagsInput extends Component {
@@ -23,16 +23,17 @@ export class TagsInput extends Component {
           event.stopPropagation();
         };
         return (
-          <EuiFilterButton key={tag.id}>
+          <EuiFlexItem grow={false}>
             <EuiBadge
               color={tag.color}
               iconType="cross"
               iconSide="right"
-              onClick={deleteTag}
+              iconOnClick={deleteTag}
+              key={tag.id}
             >
               {tag.title}
             </EuiBadge>
-          </EuiFilterButton>
+          </EuiFlexItem>
         );
       });
     }
@@ -40,15 +41,17 @@ export class TagsInput extends Component {
       return tag.id;
     });
     return (
-      <EuiFilterGroup>
+      <EuiFlexGroup gutterSize="xs" alignItems="center">
         {tags}
-        <TagsSelect
-          find={this.props.find}
-          onAdd={this.props.onAdd}
-          onDelete={this.props.onDelete}
-          usedTags={usedTags}
-        />
-      </EuiFilterGroup>
+        <EuiFlexItem grow={false}>
+          <TagsSelect
+            find={this.props.find}
+            onAdd={this.props.onAdd}
+            onDelete={this.props.onDelete}
+            usedTags={usedTags}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     );
   }
 }

--- a/src/ui/public/tags/components/tags_select.js
+++ b/src/ui/public/tags/components/tags_select.js
@@ -11,6 +11,7 @@ import {
   EuiFilterSelectItem,
   EuiIcon,
   EuiLink,
+  EuiFormHelpText,
 } from '@elastic/eui';
 
 export class TagsSelect extends Component {
@@ -149,6 +150,9 @@ export class TagsSelect extends Component {
             value={this.state.search}
             onChange={this.fetchTags}
           />
+          <EuiFormHelpText style={{ paddingBottom: 0 }}>
+            Manage and add tags over in <a href="/app/management/kibana/tags">tag management</a>
+          </EuiFormHelpText>
         </EuiPopoverTitle>
         {this.renderPopoverBody()}
       </EuiPopover>

--- a/src/ui/public/tags/components/tags_select.js
+++ b/src/ui/public/tags/components/tags_select.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import {
-  EuiFilterButton,
   EuiPopover,
   EuiPopoverTitle,
   EuiFieldSearch,
@@ -11,6 +10,7 @@ import {
   EuiSpacer,
   EuiFilterSelectItem,
   EuiIcon,
+  EuiLink,
 } from '@elastic/eui';
 
 export class TagsSelect extends Component {
@@ -74,14 +74,11 @@ export class TagsSelect extends Component {
 
   renderButton() {
     return (
-      <EuiFilterButton
-        iconType="arrowDown"
+      <EuiLink
         onClick={this.onBtnClick}
-        isSelected={this.state.show}
-        hasActiveFilters={true}
       >
-        Add Tags
-      </EuiFilterButton>
+        Attach tags
+      </EuiLink>
     );
   }
 


### PR DESCRIPTION
Made this thing a little more bare metal till we have a proper autocomplete component. It looks clean for now until we redo this whole form in EUI styling. Couple other bits you should try if you have time.

1. Only show the search input in the dropdown if the number of total tags is greater than the number you're truncating against. Right now search always shows up regardless of whether its needed.
2. Make your table pagination for the tag management table higher. These things are pretty simple, it can be larger than 10.
3. Make your search output higher. The component will scroll. I'd put as many as you feel comfortable fetching.
4. Alphabetize the tag list returned from the search dropdown.
5. I don't know that you need the checked tags in the dropdown when you already have a method to remove them in the list with the X buttons. If you do decide to keep them, at least put the checked tag list at the top of the list.
6. ~~Likely need to move your onClick on your management tags list so the hover state works correctly on `EuiBadge`. Right now it's hard to know if they are clickable.~~ Did this.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/00202y0S010g2A2K3M3Q/Screen%20Recording%202018-03-13%20at%2006.14%20PM.gif?X-CloudApp-Visitor-Id=59773&v=4174dfcf)