### PR TITLE
Improving tooltip row styles

### DIFF
--- a/x-pack/plugins/maps/public/connected_components/map/features_tooltip/_index.scss
+++ b/x-pack/plugins/maps/public/connected_components/map/features_tooltip/_index.scss
@@ -1,6 +1,5 @@
 .mapFeatureTooltip_table {
   width: 100%;
-  // display: block;
   max-height: calc(49vh - #{$euiSizeXL * 2});
 
   td {

--- a/x-pack/plugins/maps/public/connected_components/map/features_tooltip/_index.scss
+++ b/x-pack/plugins/maps/public/connected_components/map/features_tooltip/_index.scss
@@ -1,6 +1,6 @@
 .mapFeatureTooltip_table {
   width: 100%;
-  display: block;
+  // display: block;
   max-height: calc(49vh - #{$euiSizeXL * 2});
 
   td {
@@ -23,4 +23,11 @@
 .mapFeatureTooltip__propertyLabel {
   max-width: $euiSizeXL * 4;
   font-weight: $euiFontWeightSemiBold;
+}
+
+.mapFeatureTooltip_actionsRow {
+  > span {
+    display: flex;
+    justify-content: flex-end;
+  }
 }

--- a/x-pack/plugins/maps/public/connected_components/map/features_tooltip/feature_properties.js
+++ b/x-pack/plugins/maps/public/connected_components/map/features_tooltip/feature_properties.js
@@ -10,8 +10,6 @@ import {
   EuiLoadingSpinner,
   EuiTextAlign,
   EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiIcon,
   EuiContextMenu,
 } from '@elastic/eui';
@@ -168,7 +166,6 @@ export class FeatureProperties extends React.Component {
     const applyFilterButton = (
       <EuiButtonEmpty
         size="xs"
-        iconType="filter"
         title={i18n.translate('xpack.maps.tooltip.filterOnPropertyTitle', {
           defaultMessage: 'Filter on property',
         })}
@@ -181,7 +178,9 @@ export class FeatureProperties extends React.Component {
           defaultMessage: 'Filter on property',
         })}
         data-test-subj="mapTooltipCreateFilterButton"
-      />
+      >
+        <EuiIcon type="filter" />
+      </EuiButtonEmpty>
     );
 
     return this.state.actions.length === 0 ||
@@ -189,25 +188,24 @@ export class FeatureProperties extends React.Component {
         this.state.actions[0].id === ACTION_GLOBAL_APPLY_FILTER) ? (
       <td>{applyFilterButton}</td>
     ) : (
-      <td>
-        <EuiFlexGroup gutterSize="xs">
-          <EuiFlexItem grow={false}>{applyFilterButton}</EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
-              size="xs"
-              iconType="arrowRight"
-              title={i18n.translate('xpack.maps.tooltip.viewActionsTitle', {
-                defaultMessage: 'View filter actions',
-              })}
-              onClick={() => {
-                this._showFilterActions(tooltipProperty);
-              }}
-              aria-label={i18n.translate('xpack.maps.tooltip.viewActionsTitle', {
-                defaultMessage: 'View filter actions',
-              })}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+      <td className="mapFeatureTooltip_actionsRow">
+        <span>
+          {applyFilterButton}
+          <EuiButtonEmpty
+            size="xs"
+            title={i18n.translate('xpack.maps.tooltip.viewActionsTitle', {
+              defaultMessage: 'View filter actions',
+            })}
+            onClick={() => {
+              this._showFilterActions(tooltipProperty);
+            }}
+            aria-label={i18n.translate('xpack.maps.tooltip.viewActionsTitle', {
+              defaultMessage: 'View filter actions',
+            })}
+          >
+            <EuiIcon type="arrowRight" />
+          </EuiButtonEmpty>
+        </span>
       </td>
     );
   }


### PR DESCRIPTION
## Summary

Just a few styles to make the tooltip row always grow and the icons always aligned to the right.

<img width="1180" alt="tooltip-action-row-styles@2x" src="https://user-images.githubusercontent.com/2750668/91296091-f7b0f680-e793-11ea-8478-aecae0317771.png">

