### PR TITLE
ensure legacy-ids get correctly evaluated

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/ems_file_source/ems_file_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/ems_file_source/ems_file_source.tsx
@@ -72,9 +72,7 @@ export class EMSFileSource extends AbstractVectorSource implements IEmsFileSourc
 
   async getEMSFileLayer(): Promise<FileLayer> {
     const emsFileLayers = await getEmsFileLayers();
-    const emsFileLayer = emsFileLayers.find(
-      (fileLayer) => fileLayer.getId() === this._descriptor.id
-    );
+    const emsFileLayer = emsFileLayers.find((fileLayer) => fileLayer.hasId(this._descriptor.id));
     if (!emsFileLayer) {
       throw new Error(
         i18n.translate('xpack.maps.source.emsFile.unableToFindIdErrorMessage', {


### PR DESCRIPTION
Fix to how Maps finds the corresponding EMS-layer.