### PR TITLE
[Embeddable Rebuild] [Controls]  Draft of apply on reset

### DIFF
--- a/examples/controls_example/public/app/react_control_example/react_control_example.tsx
+++ b/examples/controls_example/public/app/react_control_example/react_control_example.tsx
@@ -362,8 +362,8 @@ export const ReactControlExample = ({
             <EuiFlexItem grow={false}>
               <EuiButtonEmpty
                 isDisabled={!controlGroupApi}
-                onClick={() => {
-                  controlGroupApi?.resetUnsavedChanges();
+                onClick={async () => {
+                  if (controlGroupApi) await controlGroupApi.asyncResetUnsavedChanges();
                 }}
               >
                 Reset

--- a/examples/controls_example/public/react_controls/control_group/get_control_group_factory.tsx
+++ b/examples/controls_example/public/react_controls/control_group/get_control_group_factory.tsx
@@ -113,6 +113,7 @@ export const getControlGroupEmbeddableFactory = (services: {
           ],
           labelPosition: [labelPosition$, (next: ControlStyle) => labelPosition$.next(next)],
         },
+        selectionsManager.applySelections,
         controlsManager.snapshotControlsRuntimeState,
         parentApi,
         lastSavedRuntimeState

--- a/examples/controls_example/public/react_controls/control_group/types.ts
+++ b/examples/controls_example/public/react_controls/control_group/types.ts
@@ -19,11 +19,11 @@ import {
 import {
   HasEditCapabilities,
   HasParentApi,
+  PublishesAsyncUnsavedChanges,
   PublishesDataLoading,
   PublishesFilters,
   PublishesTimeslice,
   PublishesUnifiedSearch,
-  PublishesUnsavedChanges,
   PublishingSubject,
 } from '@kbn/presentation-publishing';
 import { PublishesDataViews } from '@kbn/presentation-publishing/interfaces/publishes_data_views';
@@ -55,7 +55,7 @@ export type ControlGroupApi = PresentationContainer &
   HasSerializedChildState<ControlPanelState> &
   HasEditCapabilities &
   PublishesDataLoading &
-  PublishesUnsavedChanges &
+  PublishesAsyncUnsavedChanges &
   PublishesControlGroupDisplaySettings &
   PublishesTimeslice &
   Partial<HasParentApi<PublishesUnifiedSearch> & HasSaveNotification> & {

--- a/examples/controls_example/public/react_controls/data_controls/range_slider/get_range_slider_control_factory.tsx
+++ b/examples/controls_example/public/react_controls/data_controls/range_slider/get_range_slider_control_factory.tsx
@@ -201,7 +201,7 @@ export const getRangesliderControlFactory = (
       });
 
       if (initialState.value !== undefined) {
-        await dataControl.untilFiltersInitialized();
+        await dataControl.api.untilFiltersReady();
       }
 
       return {

--- a/examples/controls_example/public/react_controls/data_controls/search_control/get_search_control_factory.tsx
+++ b/examples/controls_example/public/react_controls/data_controls/search_control/get_search_control_factory.tsx
@@ -184,7 +184,7 @@ export const getSearchControlFactory = ({
         });
 
       if (initialState.searchString?.length) {
-        await dataControl.untilFiltersInitialized();
+        await dataControl.api.untilFiltersReady();
       }
 
       return {

--- a/examples/controls_example/public/react_controls/data_controls/types.ts
+++ b/examples/controls_example/public/react_controls/data_controls/types.ts
@@ -14,6 +14,7 @@ import {
   PublishesFilters,
   PublishesPanelTitle,
 } from '@kbn/presentation-publishing';
+import { BehaviorSubject } from 'rxjs';
 import { ControlFactory, DefaultControlApi, DefaultControlState } from '../types';
 
 export type DataControlApi = DefaultControlApi &
@@ -21,6 +22,8 @@ export type DataControlApi = DefaultControlApi &
   HasEditCapabilities &
   PublishesDataViews &
   PublishesFilters & {
+    filtersReady$: BehaviorSubject<boolean>;
+    untilFiltersReady: () => Promise<void>;
     setOutputFilter: (filter: Filter | undefined) => void; // a control should only ever output a **single** filter
   };
 

--- a/packages/presentation/presentation_publishing/index.ts
+++ b/packages/presentation/presentation_publishing/index.ts
@@ -110,6 +110,7 @@ export {
 export {
   apiPublishesUnsavedChanges,
   type PublishesUnsavedChanges,
+  type PublishesAsyncUnsavedChanges,
 } from './interfaces/publishes_unsaved_changes';
 export {
   apiPublishesViewMode,

--- a/packages/presentation/presentation_publishing/interfaces/publishes_unsaved_changes.ts
+++ b/packages/presentation/presentation_publishing/interfaces/publishes_unsaved_changes.ts
@@ -13,7 +13,14 @@ export interface PublishesUnsavedChanges<Runtime extends object = object> {
   resetUnsavedChanges: () => void;
 }
 
-export const apiPublishesUnsavedChanges = (api: unknown): api is PublishesUnsavedChanges => {
+export interface PublishesAsyncUnsavedChanges<Runtime extends object = object>
+  extends Pick<PublishesUnsavedChanges<Runtime>, 'unsavedChanges'> {
+  asyncResetUnsavedChanges: () => Promise<void>;
+}
+
+export const apiPublishesUnsavedChanges = (
+  api: unknown
+): api is PublishesUnsavedChanges | PublishesAsyncUnsavedChanges => {
   return Boolean(
     api &&
       (api as PublishesUnsavedChanges).unsavedChanges &&

--- a/src/plugins/embeddable/public/react_embeddable_system/types.ts
+++ b/src/plugins/embeddable/public/react_embeddable_system/types.ts
@@ -126,6 +126,6 @@ export interface ReactEmbeddableFactory<
      * Last saved runtime state. Different from initialRuntimeState in that it does not contain previous sessions's unsaved changes
      * Compare with initialRuntimeState to flag unsaved changes on load
      */
-    lastSavedRuntimeState: RuntimeState,
+    lastSavedRuntimeState: RuntimeState
   ) => Promise<{ Component: React.FC<{}>; api: Api }>;
 }


### PR DESCRIPTION
 This is a draft PR to show how we could apply selections on reset - the types are still angry, so we would need to resolve that before it is ready to be merged. The behaviour is also still buggy WRT initialization.